### PR TITLE
Add inactive days to created issue

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,7 +39,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://ghcr.io/github/super-linter:latest
+        uses: github/super-linter@v5
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDEA
+.idea/**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Stale Repos Action
 (Used by the `github` organization!)
 
-This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival. The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization.
+This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival. The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization. For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days.
 
 This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too! We are actively using and are archiving things in batches since there are many repositories on our report. To find out more about how GitHub manages its open source, check out the [github-ospo repository](https://github.com/github/github-ospo).
 
@@ -26,7 +26,7 @@ Below are the allowed configuration options:
 |-----------------------|----------|---------|-------------|
 | `GH_TOKEN`            | true     |         | The GitHub Token used to scan repositories. Must have read and write access to all repositories |
 | `ORGANIZATION`        | true     |         | The organization to scan for stale repositories |
-| `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale |
+| `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale, based on `push` events |
 | `GH_ENTERPRISE_URL`   | false    | `""`    | URL of GitHub Enterprise instance to use for auth instead of github.com |
 
 ### Example workflow

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ jobs:
 ```markdown
 # Inactive Repositories
 
+The following repos have not had a push event for more than 3 days:
+
 | Repository URL | Days Inactive |
 | --- | ---: |
 | https://github.com/github/.github | 5 |

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Stale Repos Action
 (Used by the `github` organization!)
 
-This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival. The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization. For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days.
+This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival.
+The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization.
+For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days.
 
-This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too! We are actively using and are archiving things in batches since there are many repositories on our report. To find out more about how GitHub manages its open source, check out the [github-ospo repository](https://github.com/github/github-ospo).
+This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too!
+We are actively using and are archiving things in batches since there are many repositories on our report.
+To find out more about how GitHub manages its open source, check out the [github-ospo repository](https://github.com/github/github-ospo).
 
 If you are looking to identify stale pull requests and issues, check out [actions/stale](https://github.com/actions/stale)
 
 ## Support
 
-If you need support using this project or have questions about it, please [open up an issue in this repository](https://github.com/github/stale-repos/issues). Requests made directly to GitHub staff or support team will be redirected here to open an issue. GitHub SLA's and support/services contracts do not apply to this repository.
+If you need support using this project or have questions about it, please [open up an issue in this repository](https://github.com/github/stale-repos/issues).
+Requests made directly to GitHub staff or support team will be redirected here to open an issue.
+GitHub SLA's and support/services contracts do not apply to this repository.
 
 ## Use as a GitHub Action
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Stale Repos Action
+(Used by the `github` organization!)
 
 This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival. The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization.
 
-This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too! To find out more about how GitHub manages its open source, check out the [github-ospo repository](https://github.com/github/github-ospo).
+This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too! We are actively using and are archiving things in batches since there are many repositories on our report. To find out more about how GitHub manages its open source, check out the [github-ospo repository](https://github.com/github/github-ospo).
 
 If you are looking to identify stale pull requests and issues, check out [actions/stale](https://github.com/actions/stale)
 
 ## Support
 
-If you need support using this project or have questions about it, please [open up an issue in this repository](https://github.com/github/stale_repos/issues). Requests made directly to GitHub staff or support team will be redirected here to open an issue. GitHub SLA's and support/services contracts do not apply to this repository.
+If you need support using this project or have questions about it, please [open up an issue in this repository](https://github.com/github/stale-repos/issues). Requests made directly to GitHub staff or support team will be redirected here to open an issue. GitHub SLA's and support/services contracts do not apply to this repository.
 
 ## Use as a GitHub Action
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -51,7 +51,7 @@ def main():
     )
 
     # Write the list of inactive repos to a csv file
-    write_to_markdown(inactive_repos)
+    write_to_markdown(inactive_repos, inactive_days_threshold)
 
 
 def get_inactive_repos(github_connection, inactive_days_threshold, organization):
@@ -81,17 +81,19 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
     return inactive_repos
 
 
-def write_to_markdown(inactive_repos, file=None):
+def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
     """Write the list of inactive repos to a markdown file.
 
     Args:
         inactive_repos: A list of tuples containing the repo and days inactive.
+        inactive_days_threshold: The threshold (in days) for considering a repo as inactive.
         file: A file object to write to. If None, a new file will be created.
 
     """
     inactive_repos.sort(key=lambda x: x[1], reverse=True)
     with file or open("stale_repos.md", "w", encoding="utf-8") as file:
         file.write("# Inactive Repositories\n\n")
+        file.write(f"The following repos have not had a push event for more than {inactive_days_threshold} days:\n\n")
         file.write("| Repository URL | Days Inactive |\n")
         file.write("| --- | ---: |\n")
         for repo_url, days_inactive in inactive_repos:

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -93,7 +93,9 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
     inactive_repos.sort(key=lambda x: x[1], reverse=True)
     with file or open("stale_repos.md", "w", encoding="utf-8") as file:
         file.write("# Inactive Repositories\n\n")
-        file.write(f"The following repos have not had a push event for more than {inactive_days_threshold} days:\n\n")
+        file.write(
+            f"The following repos have not had a push event for more than {inactive_days_threshold} days:\n\n"
+        )
         file.write("| Repository URL | Days Inactive |\n")
         file.write("| --- | ---: |\n")
         for repo_url, days_inactive in inactive_repos:

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -220,16 +220,18 @@ class WriteToMarkdownTestCase(unittest.TestCase):
             ("https://github.com/example/repo1", 30),
         ]
 
+        inactive_days_threshold = 365
+
         # Create a mock file object
         mock_file = MagicMock()
 
         # Call the write_to_markdown function with the mock file object
-        write_to_markdown(inactive_repos, file=mock_file)
+        write_to_markdown(inactive_repos, inactive_days_threshold, file=mock_file)
 
         # Check that the mock file object was called with the expected data
         expected_calls = [
             call.write("# Inactive Repositories\n\n"),
-            call.write("The following repositories have not had a push event for more than 20 days:\n\n"),
+            call.write("The following repos have not had a push event for more than 365 days:\n\n"),
             call.write("| Repository URL | Days Inactive |\n"),
             call.write("| --- | ---: |\n"),
             call.write("| https://github.com/example/repo2 | 40 |\n"),

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -231,7 +231,9 @@ class WriteToMarkdownTestCase(unittest.TestCase):
         # Check that the mock file object was called with the expected data
         expected_calls = [
             call.write("# Inactive Repositories\n\n"),
-            call.write("The following repos have not had a push event for more than 365 days:\n\n"),
+            call.write(
+                "The following repos have not had a push event for more than 365 days:\n\n"
+            ),
             call.write("| Repository URL | Days Inactive |\n"),
             call.write("| --- | ---: |\n"),
             call.write("| https://github.com/example/repo2 | 40 |\n"),

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -229,6 +229,7 @@ class WriteToMarkdownTestCase(unittest.TestCase):
         # Check that the mock file object was called with the expected data
         expected_calls = [
             call.write("# Inactive Repositories\n\n"),
+            call.write("The following repositories have not had a push event for more than 20 days:\n\n"),
             call.write("| Repository URL | Days Inactive |\n"),
             call.write("| --- | ---: |\n"),
             call.write("| https://github.com/example/repo2 | 40 |\n"),


### PR DESCRIPTION
I thought it would be nice to show how many days are considered inactive in the report, so here it is!

Another thing I did here was move from the docker image pull for super-linter to just a normal git checkout: 

`uses: docker://ghcr.io/github/super-linter:latest` -> `uses: github/super-linter@v5`. 

I did this because the linter docker download took a massive 2 minutes to pull in my action, found here: https://github.com/github/stale-repos/actions/runs/5191207461/jobs/9358729533?pr=24#step:2:1 - It doesn't seem like changing it in this file (probably because I'm on a fork) changed it for this PR, but hopefully this can speed up the linting process a bit without needing to pull an entire docker image. 

