### PR TITLE
Change deprecated set-output to GITHUB_OUTPUT environment variable

### DIFF
--- a/stale_repos.py
+++ b/stale_repos.py
@@ -130,7 +130,8 @@ def output_to_json(inactive_repos):
         inactive_repos_json.append({"url": repo_url, "daysInactive": days_inactive})
     inactive_repos_json = json.dumps(inactive_repos_json)
 
-    with open(os.environ['GITHUB_OUTPUTT'], 'a') as fh:
+    # add output to github action output
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
         print(f'inactiveRepos={inactive_repos_json}', file=fh)
     return inactive_repos_json
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -130,7 +130,7 @@ def output_to_json(inactive_repos):
         inactive_repos_json.append({"url": repo_url, "daysInactive": days_inactive})
     inactive_repos_json = json.dumps(inactive_repos_json)
 
-    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    with open(os.environ['GITHUB_OUTPUTT'], 'a') as fh:
         print(f'inactiveRepos={inactive_repos_json}', file=fh)
     return inactive_repos_json
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -130,7 +130,8 @@ def output_to_json(inactive_repos):
         inactive_repos_json.append({"url": repo_url, "daysInactive": days_inactive})
     inactive_repos_json = json.dumps(inactive_repos_json)
 
-    print(f"::set-output name=inactiveRepos::{inactive_repos_json}")
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(f'inactiveRepos={inactive_repos_json}', file=fh)
     return inactive_repos_json
 
 


### PR DESCRIPTION
`set-output` has been marked as deprecated for like 6ish months, so moving from using that to the `GITHUB_OUTPUT` env var.

@zkoppert For the record, this is how the `major-version-updater` action works too, for example:

```yaml
echo "tag=${tag}" >> "$GITHUB_OUTPUT"
```

GitHub deprecated this last fall and said it would go away this spring but not enough people properly migrated so I think it is postponed for now, but still good to get rid of. 

Fixes #31 