### PR TITLE
Enable personal accounts when no org is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Output files
+stale_repos.md
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Below are the allowed configuration options:
 | field                 | required | default | description |
 |-----------------------|----------|---------|-------------|
 | `GH_TOKEN`            | true     |         | The GitHub Token used to scan repositories. Must have read and write access to all repositories |
-| `ORGANIZATION`        | true     |         | The organization to scan for stale repositories |
+| `ORGANIZATION`        | false     |         | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner |
 | `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale, based on `push` events |
 | `GH_ENTERPRISE_URL`   | false    | `""`    | URL of GitHub Enterprise instance to use for auth instead of github.com |
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -43,7 +43,9 @@ def main():  # pragma: no cover
     # Set the organization
     organization = os.getenv("ORGANIZATION")
     if not organization:
-        raise ValueError("ORGANIZATION environment variable not set")
+        print(
+            "ORGANIZATION environment variable not set, searching all repos owned by token owner"
+        )
 
     # Iterate over repos in the org, acquire inactive days,
     # and print out the repo url and days inactive if it's over the threshold (inactive_days)
@@ -70,9 +72,12 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
 
     """
     inactive_repos = []
-    org = github_connection.organization(organization)
+    if organization:
+        repos = github_connection.organization(organization).repositories()
+    else:
+        repos = github_connection.repositories(type="owner")
 
-    for repo in org.repositories():
+    for repo in repos:
         last_push_str = repo.pushed_at  # type: ignore
         if last_push_str is None:
             continue


### PR DESCRIPTION
fixes #32 

Minor change to allow for personal account searching when an organization is not specified. I tested this with a token authorized for full repo scope and it worked! If the token has no scopes set but the default, then you will only get a readout of public repositories owned by the token owner.

cc/ @coolestowl 