### PR TITLE
Write JSON data to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The following repos have not had a push event for more than 3 days:
 
 ### Using JSON instead of Markdown
 
-The action outputs inactive repos in JSON format for further actions. 
+The action outputs inactive repos in JSON format for further actions as seen below or use the JSON contents from the file: `stale_repos.json`.
 
 Example usage:
 ```yaml

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -113,7 +113,7 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
     print("Wrote stale repos to stale_repos.md")
 
 
-def output_to_json(inactive_repos):
+def output_to_json(inactive_repos, file=None):
     """Convert the list of inactive repos to a json string.
 
     Args:
@@ -140,6 +140,13 @@ def output_to_json(inactive_repos):
     if os.environ.get("GITHUB_OUTPUT"):
         with open(os.environ["GITHUB_OUTPUT"], "a") as file_handle:
             print(f"inactiveRepos={inactive_repos_json}", file=file_handle)
+    
+   
+    with file or open("stale_repos.json", "w", encoding="utf-8") as file:
+        file.write(inactive_repos_json)
+     
+    print("Wrote stale repos to stale_repos.json")
+    
     return inactive_repos_json
 
 

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -308,6 +308,38 @@ class OutputToJson(unittest.TestCase):
         )
         actual_json = output_to_json(inactive_repos)
         assert actual_json == expected_json
+    
+    def test_json_file(self):
+        """Test that output_to_json writes JSON data to a file
+        
+        This test checks that output_to_json correctly writes its JSON data
+        to a file named "stale_repos.json"
+        """
+        # Create a list of inactive repos
+        inactive_repos = [
+            ("https://github.com/example/repo1", 31),
+            ("https://github.com/example/repo2", 30),
+            ("https://github.com/example/repo3", 29),
+        ]
+
+        # Call the output_to_json function with the list of inactive repos
+        expected_json = json.dumps(
+            [
+                {"url": "https://github.com/example/repo1", "daysInactive": 31},
+                {"url": "https://github.com/example/repo2", "daysInactive": 30},
+                {"url": "https://github.com/example/repo3", "daysInactive": 29},
+            ]
+        )
+
+        mock_file = MagicMock()
+         # Check that the mock file object was called with the expected data
+        expected_calls = [
+            call.write(expected_json),
+        ]
+
+        output_to_json(inactive_repos, mock_file)
+        mock_file.__enter__.return_value.assert_has_calls(expected_calls)
+        
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If a list of stale repositories becomes sufficiently long, dealing with it as an output is cumbersome. You may start to see errors such as "Argument list too long" when using the output in subsequent steps in GHA. 
 
This PR writes the JSON data to a a "stale_repos.json" file to make processing or extracting this JSON data easier. (In my case, I want to be able to upload the JSON data with the `actions/upload-artifact` action.)

