### PR TITLE
feat: Add exemption labels for repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GitHub SLA's and support/services contracts do not apply to this repository.
 ## Use as a GitHub Action
 
 1. Create a repository to host this GitHub Action or select an existing repository.
-1. Create the env values from the sample workflow below (GH_TOKEN, ORGANIZATION) with your information as repository secrets. More info on creating secrets can be found [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+1. Create the env values from the sample workflow below (GH_TOKEN, ORGANIZATION, EXEMPT_TOPICS) with your information as plain text or repository secrets. More info on creating secrets can be found [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
 Note: Your GitHub token will need to have read/write access to all the repositories in the organization that you want evaluated
 1. Copy the below example workflow to your repository and put it in the `.github/workflows/` directory with the file extension `.yml` (ie. `.github/workflows/stale_repos.yml`)
 
@@ -31,8 +31,9 @@ Below are the allowed configuration options:
 | field                 | required | default | description |
 |-----------------------|----------|---------|-------------|
 | `GH_TOKEN`            | true     |         | The GitHub Token used to scan repositories. Must have read and write access to all repositories |
-| `ORGANIZATION`        | false     |         | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner |
+| `ORGANIZATION`        | false    |         | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner |
 | `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale, based on `push` events |
+| `EXEMPT_TOPICS`       | false    |         | Comma separated list of topics to exempt from being flagged as stale |
 | `GH_ENTERPRISE_URL`   | false    | `""`    | URL of GitHub Enterprise instance to use for auth instead of github.com |
 
 ### Example workflow
@@ -59,6 +60,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         ORGANIZATION: ${{ secrets.ORGANIZATION }}
+        EXEMPT_TOPICS: "keep,template"
         INACTIVE_DAYS: 365
 
     - name: Create issue
@@ -111,6 +113,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         ORGANIZATION: ${{ secrets.ORGANIZATION }}
+        EXEMPT_TOPICS: "keep,template"
         INACTIVE_DAYS: 365
 
     - name: Print output of stale_repos tool
@@ -136,7 +139,8 @@ jobs:
 1. Copy `.env-example` to `.env`
 1. Fill out the `.env` file with a _token_ from a user that has access to the organization to scan (listed below). Tokens should have admin:org or read:org access.
 1. Fill out the `.env` file with the desired _inactive_days_ value. This should be a whole positive number representing the amount of inactivity that you want for flagging stale repos.
-1. Fill out the `.env` file with the exact _organization_ that you want to search in
+1. (Optional) Fill out the `.env` file with the [repository topics](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics) _exempt_topics_ that you want to filter out from the stale repos report. This should be a comma separated list of topics.
+1. (Optional) Fill out the `.env` file with the exact _organization_ that you want to search in
 1. (Optional) Fill out the `.env` file with the exact _URL_ of the GitHub Enterprise that you want to search in. Keep empty if you want to search in the  public `github.com`.
 1. `pip install -r requirements.txt`
 1. Run `python3 ./stale_repos.py`, which will output a list of repositories and the length of their inactivity


### PR DESCRIPTION
fixes #16

This pull request allows for a configurable set of repository topics to be exempt from the stale-repos report. This is useful if you have a set of repos that keep showing up on the report but should instead be ignored.

cc/ @BrycenDavisSH