### PR TITLE
feat: Add last push date to markdown and JSON output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ jobs:
 
 The following repos have not had a push event for more than 3 days:
 
-| Repository URL | Days Inactive |
-| --- | ---: |
-| https://github.com/github/.github | 5 |
+| Repository URL | Days Inactive | Last Push Date |
+| --- | ---: | ---: | 
+| https://github.com/github/.github | 5 | 2020-1-30 |
 ```
 
 ### Using JSON instead of Markdown

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -68,7 +68,7 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
         organization: The name of the organization to retrieve repositories from.
 
     Returns:
-        A list of tuples containing the repo and days inactive.
+        A list of tuples containing the repo, days inactive, and the date of the last push.
 
     """
     inactive_repos = []

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -112,7 +112,8 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
     """Write the list of inactive repos to a markdown file.
 
     Args:
-        inactive_repos: A list of tuples containing the repo and days inactive.
+        inactive_repos: A list of tuples containing the repo, days inactive,
+            and the date of the last push.
         inactive_days_threshold: The threshold (in days) for considering a repo as inactive.
         file: A file object to write to. If None, a new file will be created.
 
@@ -135,7 +136,7 @@ def output_to_json(inactive_repos, file=None):
     """Convert the list of inactive repos to a json string.
 
     Args:
-        inactive_repos: A list of tuples containing the repo and days inactive.
+        inactive_repos: A list of tuples containing the repo, days inactive, and the date of the last push.
 
     Returns:
         JSON formatted string of the list of inactive repos.

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -136,7 +136,8 @@ def output_to_json(inactive_repos, file=None):
     """Convert the list of inactive repos to a json string.
 
     Args:
-        inactive_repos: A list of tuples containing the repo, days inactive, and the date of the last push.
+        inactive_repos: A list of tuples containing the repo,
+            days inactive, and the date of the last push.
 
     Returns:
         JSON formatted string of the list of inactive repos.
@@ -152,8 +153,13 @@ def output_to_json(inactive_repos, file=None):
     # ]
     inactive_repos_json = []
     for repo_url, days_inactive, last_push_date in inactive_repos:
-        inactive_repos_json.append({"url": repo_url, "daysInactive": days_inactive,
-                                    "lastPushDate": last_push_date})
+        inactive_repos_json.append(
+            {
+                "url": repo_url,
+                "daysInactive": days_inactive,
+                "lastPushDate": last_push_date,
+            }
+        )
     inactive_repos_json = json.dumps(inactive_repos_json)
 
     # add output to github action output

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -95,7 +95,7 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
         if last_push_str is None:
             continue
         last_push = parse(last_push_str)
-        last_push_disp_date = parse(last_push_str).date().isoformat()
+        last_push_disp_date = last_push.date().isoformat()
 
         days_inactive = (datetime.now(timezone.utc) - last_push).days
         if days_inactive > int(inactive_days_threshold) and not repo.archived:

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -25,8 +25,12 @@ from unittest.mock import MagicMock, call, patch
 
 import github3.github
 
-from stale_repos import (auth_to_github, get_inactive_repos, output_to_json,
-                         write_to_markdown)
+from stale_repos import (
+    auth_to_github,
+    get_inactive_repos,
+    output_to_json,
+    write_to_markdown,
+)
 
 
 class AuthToGithubTestCase(unittest.TestCase):
@@ -365,7 +369,11 @@ class WriteToMarkdownTestCase(unittest.TestCase):
         # Create a list of inactive repos
         inactive_repos = [
             ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
-            ("https://github.com/example/repo1", 30, thirty_days_ago.date().isoformat()),
+            (
+                "https://github.com/example/repo1",
+                30,
+                thirty_days_ago.date().isoformat(),
+            ),
         ]
 
         inactive_days_threshold = 365
@@ -384,10 +392,14 @@ class WriteToMarkdownTestCase(unittest.TestCase):
             ),
             call.write("| Repository URL | Days Inactive | Last Push Date |\n"),
             call.write("| --- | --- | ---: |\n"),
-            call.write(f"| https://github.com/example/repo2 | 40 | " \
-                        f"{forty_days_ago.date().isoformat()} |\n"),
-            call.write(f"| https://github.com/example/repo1 | 30 | " \
-                        f"{thirty_days_ago.date().isoformat()} |\n"),
+            call.write(
+                f"| https://github.com/example/repo2 | 40 | "
+                f"{forty_days_ago.date().isoformat()} |\n"
+            ),
+            call.write(
+                f"| https://github.com/example/repo1 | 30 | "
+                f"{thirty_days_ago.date().isoformat()} |\n"
+            ),
         ]
         mock_file.__enter__.return_value.assert_has_calls(expected_calls)
 
@@ -410,20 +422,41 @@ class OutputToJson(unittest.TestCase):
         twenty_nine_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo1", 31, thirty_one_days_ago.date().isoformat()),
-            ("https://github.com/example/repo2", 30, thirty_days_ago.date().isoformat()),
-            ("https://github.com/example/repo3", 29, twenty_nine_days_ago.date().isoformat()),
+            (
+                "https://github.com/example/repo1",
+                31,
+                thirty_one_days_ago.date().isoformat(),
+            ),
+            (
+                "https://github.com/example/repo2",
+                30,
+                thirty_days_ago.date().isoformat(),
+            ),
+            (
+                "https://github.com/example/repo3",
+                29,
+                twenty_nine_days_ago.date().isoformat(),
+            ),
         ]
 
         # Call the output_to_json function with the list of inactive repos
         expected_json = json.dumps(
             [
-                {"url": "https://github.com/example/repo1", "daysInactive": 31,
-                 "lastPushDate": thirty_one_days_ago.date().isoformat()},
-                {"url": "https://github.com/example/repo2", "daysInactive": 30,
-                 "lastPushDate": thirty_days_ago.date().isoformat()},
-                {"url": "https://github.com/example/repo3", "daysInactive": 29,
-                 "lastPushDate": twenty_nine_days_ago.date().isoformat()},
+                {
+                    "url": "https://github.com/example/repo1",
+                    "daysInactive": 31,
+                    "lastPushDate": thirty_one_days_ago.date().isoformat(),
+                },
+                {
+                    "url": "https://github.com/example/repo2",
+                    "daysInactive": 30,
+                    "lastPushDate": thirty_days_ago.date().isoformat(),
+                },
+                {
+                    "url": "https://github.com/example/repo3",
+                    "daysInactive": 29,
+                    "lastPushDate": twenty_nine_days_ago.date().isoformat(),
+                },
             ]
         )
         actual_json = output_to_json(inactive_repos)
@@ -440,20 +473,41 @@ class OutputToJson(unittest.TestCase):
         twenty_nine_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo1", 31, thirty_one_days_ago.date().isoformat()),
-            ("https://github.com/example/repo2", 30, thirty_days_ago.date().isoformat()),
-            ("https://github.com/example/repo3", 29, twenty_nine_days_ago.date().isoformat()),
+            (
+                "https://github.com/example/repo1",
+                31,
+                thirty_one_days_ago.date().isoformat(),
+            ),
+            (
+                "https://github.com/example/repo2",
+                30,
+                thirty_days_ago.date().isoformat(),
+            ),
+            (
+                "https://github.com/example/repo3",
+                29,
+                twenty_nine_days_ago.date().isoformat(),
+            ),
         ]
 
         # Call the output_to_json function with the list of inactive repos
         expected_json = json.dumps(
             [
-                {"url": "https://github.com/example/repo1", "daysInactive": 31,
-                 "lastPushDate": thirty_one_days_ago.date().isoformat()},
-                {"url": "https://github.com/example/repo2", "daysInactive": 30,
-                 "lastPushDate": thirty_days_ago.date().isoformat()},
-                {"url": "https://github.com/example/repo3", "daysInactive": 29,
-                 "lastPushDate": twenty_nine_days_ago.date().isoformat()},
+                {
+                    "url": "https://github.com/example/repo1",
+                    "daysInactive": 31,
+                    "lastPushDate": thirty_one_days_ago.date().isoformat(),
+                },
+                {
+                    "url": "https://github.com/example/repo2",
+                    "daysInactive": 30,
+                    "lastPushDate": thirty_days_ago.date().isoformat(),
+                },
+                {
+                    "url": "https://github.com/example/repo3",
+                    "daysInactive": 29,
+                    "lastPushDate": twenty_nine_days_ago.date().isoformat(),
+                },
             ]
         )
 

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -25,12 +25,8 @@ from unittest.mock import MagicMock, call, patch
 
 import github3.github
 
-from stale_repos import (
-    auth_to_github,
-    get_inactive_repos,
-    output_to_json,
-    write_to_markdown,
-)
+from stale_repos import (auth_to_github, get_inactive_repos, output_to_json,
+                         write_to_markdown)
 
 
 class AuthToGithubTestCase(unittest.TestCase):
@@ -204,7 +200,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -345,7 +341,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -364,11 +360,12 @@ class WriteToMarkdownTestCase(unittest.TestCase):
         the mock file object was called with the expected data.
 
         """
-
+        forty_days_ago = datetime.now(timezone.utc) - timedelta(days=40)
+        thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo2", 40),
-            ("https://github.com/example/repo1", 30),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo1", 30, thirty_days_ago.date().isoformat()),
         ]
 
         inactive_days_threshold = 365
@@ -385,10 +382,12 @@ class WriteToMarkdownTestCase(unittest.TestCase):
             call.write(
                 "The following repos have not had a push event for more than 365 days:\n\n"
             ),
-            call.write("| Repository URL | Days Inactive |\n"),
-            call.write("| --- | ---: |\n"),
-            call.write("| https://github.com/example/repo2 | 40 |\n"),
-            call.write("| https://github.com/example/repo1 | 30 |\n"),
+            call.write("| Repository URL | Days Inactive | Last Push Date |\n"),
+            call.write("| --- | --- | ---: |\n"),
+            call.write(f"| https://github.com/example/repo2 | 40 | " \
+                        f"{forty_days_ago.date().isoformat()} |\n"),
+            call.write(f"| https://github.com/example/repo1 | 30 | " \
+                        f"{thirty_days_ago.date().isoformat()} |\n"),
         ]
         mock_file.__enter__.return_value.assert_has_calls(expected_calls)
 
@@ -406,19 +405,25 @@ class OutputToJson(unittest.TestCase):
         function returns the expected json string.
 
         """
+        thirty_one_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+        thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+        twenty_nine_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo1", 31),
-            ("https://github.com/example/repo2", 30),
-            ("https://github.com/example/repo3", 29),
+            ("https://github.com/example/repo1", 31, thirty_one_days_ago.date().isoformat()),
+            ("https://github.com/example/repo2", 30, thirty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo3", 29, twenty_nine_days_ago.date().isoformat()),
         ]
 
         # Call the output_to_json function with the list of inactive repos
         expected_json = json.dumps(
             [
-                {"url": "https://github.com/example/repo1", "daysInactive": 31},
-                {"url": "https://github.com/example/repo2", "daysInactive": 30},
-                {"url": "https://github.com/example/repo3", "daysInactive": 29},
+                {"url": "https://github.com/example/repo1", "daysInactive": 31,
+                 "lastPushDate": thirty_one_days_ago.date().isoformat()},
+                {"url": "https://github.com/example/repo2", "daysInactive": 30,
+                 "lastPushDate": thirty_days_ago.date().isoformat()},
+                {"url": "https://github.com/example/repo3", "daysInactive": 29,
+                 "lastPushDate": twenty_nine_days_ago.date().isoformat()},
             ]
         )
         actual_json = output_to_json(inactive_repos)
@@ -430,19 +435,25 @@ class OutputToJson(unittest.TestCase):
         This test checks that output_to_json correctly writes its JSON data
         to a file named "stale_repos.json"
         """
+        thirty_one_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+        thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+        twenty_nine_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo1", 31),
-            ("https://github.com/example/repo2", 30),
-            ("https://github.com/example/repo3", 29),
+            ("https://github.com/example/repo1", 31, thirty_one_days_ago.date().isoformat()),
+            ("https://github.com/example/repo2", 30, thirty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo3", 29, twenty_nine_days_ago.date().isoformat()),
         ]
 
         # Call the output_to_json function with the list of inactive repos
         expected_json = json.dumps(
             [
-                {"url": "https://github.com/example/repo1", "daysInactive": 31},
-                {"url": "https://github.com/example/repo2", "daysInactive": 30},
-                {"url": "https://github.com/example/repo3", "daysInactive": 29},
+                {"url": "https://github.com/example/repo1", "daysInactive": 31,
+                 "lastPushDate": thirty_one_days_ago.date().isoformat()},
+                {"url": "https://github.com/example/repo2", "daysInactive": 30,
+                 "lastPushDate": thirty_days_ago.date().isoformat()},
+                {"url": "https://github.com/example/repo3", "daysInactive": 29,
+                 "lastPushDate": twenty_nine_days_ago.date().isoformat()},
             ]
         )
 


### PR DESCRIPTION
Closes #48 🚀

This PR adds the last push date to the markdown and JSON output generated at the end. The last push date is already available but not added to the output. Having an absolute date is convenient compared to the number of days. There may be a need to document the data for official reports internally (governance, IT, DevOps hygiene reports). Also, dates are easier to remember.

Ps. I've updated the test cases as well. No new test cases were needed.

Cheers!