### PR TITLE
doc: update the issue instead of creating a new one in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
         EXEMPT_TOPICS: "keep,template"
         INACTIVE_DAYS: 365
 
+    # This next step updates an existing issue. If you want a new issue every time, remove this step and remove the `issue-number: ${{ env.issue_number }}` line below.
     - name: Check for the stale report issue
       run: |
         ISSUE_NUMBER=$(gh search issues "Stale repository report" --match title --json number --jq ".[0].number")

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v3
+
     - name: Run stale_repos tool
       uses: github/stale-repos@v1
       env:
@@ -61,9 +63,17 @@ jobs:
         EXEMPT_TOPICS: "keep,template"
         INACTIVE_DAYS: 365
 
+    - name: Check for the stale report issue
+      run: |
+        ISSUE_NUMBER=$(gh search issues "Stale repository report" --match title --json number --jq ".[0].number")
+        echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_ENV"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create issue
       uses: peter-evans/create-issue-from-file@v4
       with:
+        issue-number: ${{ env.issue_number }}
         title: Stale repository report
         content-filepath: ./stale_repos.md
         assignees: <YOUR_GITHUB_HANDLE_HERE>


### PR DESCRIPTION
This is the workflow we use in in [github.com/italia](https://github.com/italia/.github/blob/main/.github/workflows/stale-repos.yml).

Fix #59.