### PR TITLE
support patterns in EXEMPT_REPOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Note: Your GitHub token will need to have read access to all the repositories in
 
 Below are the allowed configuration options:
 
-| field                 | required | default | description |
-|-----------------------|----------|---------|-------------|
-| `GH_TOKEN`            | true     |         | The GitHub Token used to scan repositories. Must have read access to all repositories you are interested in scanning |
-| `ORGANIZATION`        | false    |         | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner |
-| `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale, based on `push` events |
-| `EXEMPT_TOPICS`       | false    |         | Comma separated list of topics to exempt from being flagged as stale |
-| `EXEMPT_REPOS`        | false    |         | Comma separated list of repositories to exempt from being flagged as stale. ie. `EXEMPT_REPOS = "stale-repos,test-repo"` |
-| `GH_ENTERPRISE_URL`   | false    | `""`    | URL of GitHub Enterprise instance to use for auth instead of github.com |
+| field                 | required | default | description                                                                                                                                                          |
+|-----------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `GH_TOKEN`            | true     |         | The GitHub Token used to scan repositories. Must have read access to all repositories you are interested in scanning                                                 |
+| `ORGANIZATION`        | false    |         | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner              |
+| `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale, based on `push` events                                                                                  |
+| `EXEMPT_TOPICS`       | false    |         | Comma separated list of topics to exempt from being flagged as stale                                                                                                 |
+| `EXEMPT_REPOS`        | false    |         | Comma separated list of repositories to exempt from being flagged as stale. Supports Unix shell-style wildcards. ie. `EXEMPT_REPOS = "stale-repos,test-repo,conf-*"` |
+| `GH_ENTERPRISE_URL`   | false    | `""`    | URL of GitHub Enterprise instance to use for auth instead of github.com                                                                                              |
 
 ### Example workflow
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Find stale repositories in a GitHub organization. """
-
+import fnmatch
 import json
 import os
 from datetime import datetime, timezone
@@ -71,7 +71,7 @@ def is_repo_exempt(repo, exempt_repos, exempt_topics):
     Returns:
         True if the repo is exempt from the stale repo check, False otherwise.
     """
-    if exempt_repos and any(repo.name == exempt_repo for exempt_repo in exempt_repos):
+    if exempt_repos and any(fnmatch.fnmatchcase(repo.name, pattern) for pattern in exempt_repos):
         print(f"{repo.html_url} is exempt from stale repo check")
         return True
     try:

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -532,13 +532,23 @@ class TestIsRepoExempt(unittest.TestCase):
         Test that a repo is exempt if its name is in the exempt_repos list.
         """
         repo = MagicMock(name="repo", spec=["name", "html_url"])
-        repo.name = "exempt_repo"
-        exempt_repos = ["exempt_repo"]
         exempt_topics = []
 
-        result = is_repo_exempt(repo, exempt_repos, exempt_topics)
+        test_cases = [
+            ("exempt_repo", ["exempt_repo"], True),
+            ("data-repo", ["data-*", "conf-*"], True),
+            ("conf-repo", ["exempt_repo", "conf-*"], True),
+            ("conf", ["conf-*"], False),
+            ("repo", ["repo1", "repo-"], False),
+        ]
 
-        self.assertTrue(result)
+        for repo_name, exempt_repos, expected_result in test_cases:
+            with self.subTest(repo_name=repo_name, exempt_repos=exempt_repos):
+                repo.name = repo_name
+                repo.html_url = repo_name
+
+                result = is_repo_exempt(repo, exempt_repos, exempt_topics)
+                self.assertEqual(result, expected_result)
 
     def test_exempt_topics(self):
         """

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -540,6 +540,7 @@ class TestIsRepoExempt(unittest.TestCase):
             ("conf-repo", ["exempt_repo", "conf-*"], True),
             ("conf", ["conf-*"], False),
             ("repo", ["repo1", "repo-"], False),
+            ("repo", [""], False),
         ]
 
         for repo_name, exempt_repos, expected_result in test_cases:


### PR DESCRIPTION
hi, this closes #67.
used [fnmatch](https://docs.python.org/3/library/fnmatch.html) (unix shell-style wildcards) for simplicity.