### PR TITLE
Support determining activity date from default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival.
 The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization.
-For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days.
+For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days (can also be configured to determine activity based on default branch).
 
 This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too!
 We are actively using and are archiving things in batches since there are many repositories on our report.
@@ -30,12 +30,13 @@ Below are the allowed configuration options:
 
 | field                 | required | default | description                                                                                                                                                          |
 |-----------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `GH_TOKEN`            | true     |         | The GitHub Token used to scan repositories. Must have read access to all repositories you are interested in scanning                                                 |
-| `ORGANIZATION`        | false    |         | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner              |
-| `INACTIVE_DAYS`       | true     |         | The number of days used to determine if repository is stale, based on `push` events                                                                                  |
-| `EXEMPT_TOPICS`       | false    |         | Comma separated list of topics to exempt from being flagged as stale                                                                                                 |
-| `EXEMPT_REPOS`        | false    |         | Comma separated list of repositories to exempt from being flagged as stale. Supports Unix shell-style wildcards. ie. `EXEMPT_REPOS = "stale-repos,test-repo,conf-*"` |
-| `GH_ENTERPRISE_URL`   | false    | `""`    | URL of GitHub Enterprise instance to use for auth instead of github.com                                                                                              |
+| `GH_TOKEN`            | true     |            | The GitHub Token used to scan repositories. Must have read access to all repositories you are interested in scanning                                                 |
+| `ORGANIZATION`        | false    |            | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner              |
+| `INACTIVE_DAYS`       | true     |            | The number of days used to determine if repository is stale, based on `push` events                                                                                  |
+| `EXEMPT_TOPICS`       | false    |            | Comma separated list of topics to exempt from being flagged as stale                                                                                                 |
+| `EXEMPT_REPOS`        | false    |            | Comma separated list of repositories to exempt from being flagged as stale. Supports Unix shell-style wildcards. ie. `EXEMPT_REPOS = "stale-repos,test-repo,conf-*"` |
+| `GH_ENTERPRISE_URL`   | false    | `""`       | URL of GitHub Enterprise instance to use for auth instead of github.com                                                                                              |
+| `ACTIVITY_METHOD`     | false    | `"pushed"` | How to get the last active date of the repository. Defaults to `pushed`, which is the last time any branch had a push. Can also be set to `default_branch_updated` to instead measure from the latest commit on the default branch (good for filtering out dependabot )       |
 
 ### Example workflow
 
@@ -62,6 +63,7 @@ jobs:
         ORGANIZATION: ${{ secrets.ORGANIZATION }}
         EXEMPT_TOPICS: "keep,template"
         INACTIVE_DAYS: 365
+        ACTIVITY_METHOD: "pushed"
 
     # This next step updates an existing issue. If you want a new issue every time, remove this step and remove the `issue-number: ${{ env.issue_number }}` line below.
     - name: Check for the stale report issue

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival.
 The current approach assumes that the repos that you want to evaluate are available in a single GitHub organization.
-For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days (can also be configured to determine activity based on default branch).
+For the purpose of this action, a repository is considered inactive if it has not had a `push` in a configurable amount of days (can also be configured to determine activity based on default branch. See `ACTIVITY_METHOD` for more details.).
 
 This action was developed by GitHub so that we can keep our open source projects well maintained, and it was made open source in the hopes that it would help you too!
 We are actively using and are archiving things in batches since there are many repositories on our report.

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -151,7 +151,7 @@ def get_active_date(repo):
     Returns:
         A date object representing the last activity date of the repository.
     """
-    activity_method = os.getenv("ACTIVITY_METHOD", "pushed")
+    activity_method = os.getenv("ACTIVITY_METHOD", "pushed").lower()
     if activity_method == "default_branch_updated":
         commit = repo.branch(repo.default_branch).commit
         active_date = parse(commit.commit.as_dict()['committer']['date'])

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -154,18 +154,19 @@ def get_active_date(repo):
     activity_method = os.getenv("ACTIVITY_METHOD", "pushed").lower()
     if activity_method == "default_branch_updated":
         commit = repo.branch(repo.default_branch).commit
-        active_date = parse(commit.commit.as_dict()['committer']['date'])
+        active_date = parse(commit.commit.as_dict()["committer"]["date"])
     elif activity_method == "pushed":
         last_push_str = repo.pushed_at  # type: ignored
         if last_push_str is None:
             return None
         active_date = parse(last_push_str)
     else:
-        raise ValueError(f"""
+        raise ValueError(
+            f"""
                          ACTIVITY_METHOD environment variable has unsupported value: '{activity_method}'.
                          Allowed values are: 'pushed' and 'default_branch_updated'
                          """
-                         )
+        )
     return active_date
 
 


### PR DESCRIPTION
# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->
New Staleness criteria: latest default_branch commit 

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Support determining activity date from default branch rather than most recent push to any branch

`ACTIVITY_METHOD` defaults to the current behavior: `repo.pushed_at` aka `"pushed"`

However, I think the most recent commit to the default branch (`default_branch_updated`) is another valid way of determining staleness/activity.

Our organization uses dependabot, which continues to open PRs and push commits to repositories which have not had any human contribution in more than a year.

With this change, we will easily be able to surface repositories that otherwise would be missed due to bot activity keeping them "fresh".

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
