### PR TITLE
return None in case of a github exception for get_active_date

### DIFF
--- a/stale_repos.py
+++ b/stale_repos.py
@@ -164,9 +164,9 @@ def get_active_date(repo):
         else:
             raise ValueError(
                 f"""
-                        ACTIVITY_METHOD environment variable has unsupported value: '{activity_method}'.
-                        Allowed values are: 'pushed' and 'default_branch_updated'
-                        """
+                ACTIVITY_METHOD environment variable has unsupported value: '{activity_method}'.
+                Allowed values are: 'pushed' and 'default_branch_updated'
+                """
             )
     except github3.exceptions.GitHubException:
         print(f"{repo.html_url} had an exception trying to get the activity date.")

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -152,21 +152,25 @@ def get_active_date(repo):
         A date object representing the last activity date of the repository.
     """
     activity_method = os.getenv("ACTIVITY_METHOD", "pushed").lower()
-    if activity_method == "default_branch_updated":
-        commit = repo.branch(repo.default_branch).commit
-        active_date = parse(commit.commit.as_dict()["committer"]["date"])
-    elif activity_method == "pushed":
-        last_push_str = repo.pushed_at  # type: ignored
-        if last_push_str is None:
-            return None
-        active_date = parse(last_push_str)
-    else:
-        raise ValueError(
-            f"""
-                         ACTIVITY_METHOD environment variable has unsupported value: '{activity_method}'.
-                         Allowed values are: 'pushed' and 'default_branch_updated'
-                         """
-        )
+    try:
+        if activity_method == "default_branch_updated":
+            commit = repo.branch(repo.default_branch).commit
+            active_date = parse(commit.commit.as_dict()["committer"]["date"])
+        elif activity_method == "pushed":
+            last_push_str = repo.pushed_at  # type: ignored
+            if last_push_str is None:
+                return None
+            active_date = parse(last_push_str)
+        else:
+            raise ValueError(
+                f"""
+                        ACTIVITY_METHOD environment variable has unsupported value: '{activity_method}'.
+                        Allowed values are: 'pushed' and 'default_branch_updated'
+                        """
+            )
+    except github3.exceptions.GitHubException:
+        print(f"{repo.html_url} had an exception trying to get the activity date.")
+        return None
     return active_date
 
 

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -26,11 +26,11 @@ from unittest.mock import MagicMock, call, patch
 import github3.github
 from stale_repos import (
     auth_to_github,
+    get_active_date,
     get_inactive_repos,
     is_repo_exempt,
     output_to_json,
     write_to_markdown,
-    get_active_date,
 )
 
 

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -30,6 +30,7 @@ from stale_repos import (
     is_repo_exempt,
     output_to_json,
     write_to_markdown,
+    get_active_date,
 )
 
 
@@ -468,6 +469,29 @@ class WriteToMarkdownTestCase(unittest.TestCase):
             ),
         ]
         mock_file.__enter__.return_value.assert_has_calls(expected_calls)
+
+
+@patch.dict(os.environ, {"ACTIVITY_METHOD": "default_branch_updated"})
+class GetActiveDateTestCase(unittest.TestCase):
+    """
+    Unit test case for the get_active_date() function.
+
+    This test case class verifies that get_active_date will return None if
+    github3 throws any kind of exception.
+    """
+
+    def test_returns_none_for_exception(self):
+        """Test that get will return None if github3 throws any kind of exception."""
+        repo = MagicMock(
+            name="repo", default_branch="main", spec=["branch", "html_url"]
+        )
+
+        repo.branch.side_effect = github3.exceptions.NotFoundError(
+            resp=MagicMock(status_code=404)
+        )
+        result = get_active_date(repo)
+
+        assert result is None
 
 
 class OutputToJson(unittest.TestCase):


### PR DESCRIPTION
# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

Occasionally repo.get_branch can raise an exception: `github3.exceptions.NotFoundError: 404 Branch not found`
Even when called on the repo's default branch!

This error handling is a bit overzealous, but I think we want the action to keep trucking along in the event of one repo having an issue.


## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Catch any exeption or error raised by the `github3` while trying to `get_active_date()` and return None for that repo.  It's not elegant, but it'll do.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
