### PR TITLE
feat: add repository visibility (public/private) to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Stale Repos Action
+
 (Used by the `github` organization!)
 
 This project identifies and reports repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival.
@@ -91,9 +92,9 @@ jobs:
 
 The following repos have not had a push event for more than 3 days:
 
-| Repository URL | Days Inactive | Last Push Date |
-| --- | ---: | ---: | 
-| https://github.com/github/.github | 5 | 2020-1-30 |
+| Repository URL | Days Inactive | Last Push Date | Visibility |
+| --- | ---: | ---: | ---: | 
+| https://github.com/github/.github | 5 | 2020-1-30 | private |
 ```
 
 ### Using JSON instead of Markdown
@@ -101,6 +102,7 @@ The following repos have not had a push event for more than 3 days:
 The action outputs inactive repos in JSON format for further actions as seen below or use the JSON contents from the file: `stale_repos.json`.
 
 Example usage:
+
 ```yaml
 name: stale repo identifier
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -133,10 +133,10 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
 
         active_date_disp = active_date.date().isoformat()
         days_inactive = (datetime.now(timezone.utc) - active_date).days
-        private = "private" if repo.private else "public"
+        visibility = "private" if repo.private else "public"
         if days_inactive > int(inactive_days_threshold) and not repo.archived:
             inactive_repos.append(
-                (repo.html_url, days_inactive, active_date_disp, private)
+                (repo.html_url, days_inactive, active_date_disp, visibility)
             )
             print(f"{repo.html_url}: {days_inactive} days inactive")  # type: ignore
     if organization:
@@ -197,9 +197,9 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
         )
         file.write("| Repository URL | Days Inactive | Last Push Date | Visibility |\n")
         file.write("| --- | --- | --- | ---: |\n")
-        for repo_url, days_inactive, last_push_date, private in inactive_repos:
+        for repo_url, days_inactive, last_push_date, visibility in inactive_repos:
             file.write(
-                f"| {repo_url} | {days_inactive} | {last_push_date} | {private} |\n"
+                f"| {repo_url} | {days_inactive} | {last_push_date} | {visibility} |\n"
             )
     print("Wrote stale repos to stale_repos.md")
 
@@ -225,13 +225,13 @@ def output_to_json(inactive_repos, file=None):
     #   }
     # ]
     inactive_repos_json = []
-    for repo_url, days_inactive, last_push_date, private in inactive_repos:
+    for repo_url, days_inactive, last_push_date, visibility in inactive_repos:
         inactive_repos_json.append(
             {
                 "url": repo_url,
                 "daysInactive": days_inactive,
                 "lastPushDate": last_push_date,
-                "visibility": private,
+                "visibility": visibility,
             }
         )
     inactive_repos_json = json.dumps(inactive_repos_json)

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -135,7 +135,9 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
         days_inactive = (datetime.now(timezone.utc) - active_date).days
         private = "private" if repo.private else "public"
         if days_inactive > int(inactive_days_threshold) and not repo.archived:
-            inactive_repos.append((repo.html_url, days_inactive, active_date_disp, private))
+            inactive_repos.append(
+                (repo.html_url, days_inactive, active_date_disp, private)
+            )
             print(f"{repo.html_url}: {days_inactive} days inactive")  # type: ignore
     if organization:
         print(f"Found {len(inactive_repos)} stale repos in {organization}")
@@ -196,7 +198,9 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
         file.write("| Repository URL | Days Inactive | Last Push Date | Visibility |\n")
         file.write("| --- | --- | --- | ---: |\n")
         for repo_url, days_inactive, last_push_date, private in inactive_repos:
-            file.write(f"| {repo_url} | {days_inactive} | {last_push_date} | {private} |\n")
+            file.write(
+                f"| {repo_url} | {days_inactive} | {last_push_date} | {private} |\n"
+            )
     print("Wrote stale repos to stale_repos.md")
 
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -101,7 +101,8 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
         organization: The name of the organization to retrieve repositories from.
 
     Returns:
-        A list of tuples containing the repo, days inactive, and the date of the last push.
+        A list of tuples containing the repo, days inactive, the date of the last push and
+        repository visibility (public/private).
 
     """
     inactive_repos = []
@@ -132,8 +133,9 @@ def get_inactive_repos(github_connection, inactive_days_threshold, organization)
 
         active_date_disp = active_date.date().isoformat()
         days_inactive = (datetime.now(timezone.utc) - active_date).days
+        private = "private" if repo.private else "public"
         if days_inactive > int(inactive_days_threshold) and not repo.archived:
-            inactive_repos.append((repo.html_url, days_inactive, active_date_disp))
+            inactive_repos.append((repo.html_url, days_inactive, active_date_disp, private))
             print(f"{repo.html_url}: {days_inactive} days inactive")  # type: ignore
     if organization:
         print(f"Found {len(inactive_repos)} stale repos in {organization}")
@@ -179,7 +181,7 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
 
     Args:
         inactive_repos: A list of tuples containing the repo, days inactive,
-            and the date of the last push.
+            the date of the last push, and repository visibility (public/private).
         inactive_days_threshold: The threshold (in days) for considering a repo as inactive.
         file: A file object to write to. If None, a new file will be created.
 
@@ -191,10 +193,10 @@ def write_to_markdown(inactive_repos, inactive_days_threshold, file=None):
             f"The following repos have not had a push event for more than "
             f"{inactive_days_threshold} days:\n\n"
         )
-        file.write("| Repository URL | Days Inactive | Last Push Date |\n")
-        file.write("| --- | --- | ---: |\n")
-        for repo_url, days_inactive, last_push_date in inactive_repos:
-            file.write(f"| {repo_url} | {days_inactive} | {last_push_date} |\n")
+        file.write("| Repository URL | Days Inactive | Last Push Date | Visibility |\n")
+        file.write("| --- | --- | --- | ---: |\n")
+        for repo_url, days_inactive, last_push_date, private in inactive_repos:
+            file.write(f"| {repo_url} | {days_inactive} | {last_push_date} | {private} |\n")
     print("Wrote stale repos to stale_repos.md")
 
 
@@ -203,7 +205,8 @@ def output_to_json(inactive_repos, file=None):
 
     Args:
         inactive_repos: A list of tuples containing the repo,
-            days inactive, and the date of the last push.
+            days inactive, the date of the last push, and
+            visiblity of the repository (public/private).
 
     Returns:
         JSON formatted string of the list of inactive repos.
@@ -218,12 +221,13 @@ def output_to_json(inactive_repos, file=None):
     #   }
     # ]
     inactive_repos_json = []
-    for repo_url, days_inactive, last_push_date in inactive_repos:
+    for repo_url, days_inactive, last_push_date, private in inactive_repos:
         inactive_repos_json.append(
             {
                 "url": repo_url,
                 "daysInactive": days_inactive,
                 "lastPushDate": last_push_date,
+                "visibility": private,
             }
         )
     inactive_repos_json = json.dumps(inactive_repos_json)

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -488,6 +488,9 @@ class WriteToMarkdownTestCase(unittest.TestCase):
                 "The following repos have not had a push event for more than 365 days:\n\n"
             ),
             call.write("| Repository URL | Days Inactive | Last Push Date | Visibility |\n"),
+            call.write(
+                "| Repository URL | Days Inactive | Last Push Date | Visibility | "
+            ),
             call.write("| --- | --- | --- | ---: |\n"),
             call.write(
                 f"| https://github.com/example/repo2 | 40 | "

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -208,7 +208,12 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "private"),
+            (
+                "https://github.com/example/repo2",
+                40,
+                forty_days_ago.date().isoformat(),
+                "private",
+            ),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -352,7 +357,12 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "private"),
+            (
+                "https://github.com/example/repo2",
+                40,
+                forty_days_ago.date().isoformat(),
+                "private",
+            ),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -421,7 +431,12 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "private"),
+            (
+                "https://github.com/example/repo2",
+                40,
+                forty_days_ago.date().isoformat(),
+                "private",
+            ),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -444,7 +459,12 @@ class WriteToMarkdownTestCase(unittest.TestCase):
         thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "public"),
+            (
+                "https://github.com/example/repo2",
+                40,
+                forty_days_ago.date().isoformat(),
+                "public",
+            ),
             (
                 "https://github.com/example/repo1",
                 30,

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -488,7 +488,7 @@ class WriteToMarkdownTestCase(unittest.TestCase):
                 "The following repos have not had a push event for more than 365 days:\n\n"
             ),
             call.write(
-                "| Repository URL | Days Inactive | Last Push Date | Visibility | "
+                "| Repository URL | Days Inactive | Last Push Date | Visibility |\n"
             ),
             call.write("| --- | --- | --- | ---: |\n"),
             call.write(

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -176,18 +176,21 @@ class GetInactiveReposTestCase(unittest.TestCase):
             html_url="https://github.com/example/repo1",
             pushed_at=twenty_days_ago.isoformat(),
             archived=False,
+            private=True,
         )
         mock_repo1.topics().names = []
         mock_repo2 = MagicMock(
             html_url="https://github.com/example/repo2",
             pushed_at=forty_days_ago.isoformat(),
             archived=False,
+            private=True,
         )
         mock_repo2.topics().names = []
         mock_repo3 = MagicMock(
             html_url="https://github.com/example/repo3",
             pushed_at=forty_days_ago.isoformat(),
             archived=True,
+            private=True,
         )
         mock_repo3.topics().names = []
 
@@ -205,7 +208,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "private"),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -318,18 +321,21 @@ class GetInactiveReposTestCase(unittest.TestCase):
             html_url="https://github.com/example/repo1",
             pushed_at=twenty_days_ago.isoformat(),
             archived=False,
+            private=True,
         )
         mock_repo1.topics().names = []
         mock_repo2 = MagicMock(
             html_url="https://github.com/example/repo2",
             pushed_at=forty_days_ago.isoformat(),
             archived=False,
+            private=True,
         )
         mock_repo2.topics().names = []
         mock_repo3 = MagicMock(
             html_url="https://github.com/example/repo3",
             pushed_at=forty_days_ago.isoformat(),
             archived=True,
+            private=True,
         )
         mock_repo3.topics().names = []
 
@@ -346,7 +352,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "private"),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -376,6 +382,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
             html_url="https://github.com/example/repo1",
             default_branch="master",
             archived=False,
+            private=True,
         )
         mock_repo1.topics().names = []
         mock_repo1.branch().commit.commit.as_dict = MagicMock(
@@ -384,6 +391,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
         mock_repo2 = MagicMock(
             html_url="https://github.com/example/repo2",
             archived=False,
+            private=True,
         )
         mock_repo2.topics().names = []
         mock_repo2.branch().commit.commit.as_dict = MagicMock(
@@ -392,6 +400,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
         mock_repo3 = MagicMock(
             html_url="https://github.com/example/repo3",
             archived=True,
+            private=True,
         )
         mock_repo3.topics().names = []
         mock_repo3.branch().commit.commit.as_dict = MagicMock(
@@ -412,7 +421,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
 
         # Check that the function returns the expected list of inactive repos
         expected_inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "private"),
         ]
         assert inactive_repos == expected_inactive_repos
 
@@ -435,11 +444,12 @@ class WriteToMarkdownTestCase(unittest.TestCase):
         thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
         # Create a list of inactive repos
         inactive_repos = [
-            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat()),
+            ("https://github.com/example/repo2", 40, forty_days_ago.date().isoformat(), "public"),
             (
                 "https://github.com/example/repo1",
                 30,
                 thirty_days_ago.date().isoformat(),
+                "private",
             ),
         ]
 
@@ -457,15 +467,17 @@ class WriteToMarkdownTestCase(unittest.TestCase):
             call.write(
                 "The following repos have not had a push event for more than 365 days:\n\n"
             ),
-            call.write("| Repository URL | Days Inactive | Last Push Date |\n"),
-            call.write("| --- | --- | ---: |\n"),
+            call.write("| Repository URL | Days Inactive | Last Push Date | Visibility |\n"),
+            call.write("| --- | --- | --- | ---: |\n"),
             call.write(
                 f"| https://github.com/example/repo2 | 40 | "
-                f"{forty_days_ago.date().isoformat()} |\n"
+                f"{forty_days_ago.date().isoformat()} | "
+                f"public |\n"
             ),
             call.write(
                 f"| https://github.com/example/repo1 | 30 | "
-                f"{thirty_days_ago.date().isoformat()} |\n"
+                f"{thirty_days_ago.date().isoformat()} | "
+                f"private |\n"
             ),
         ]
         mock_file.__enter__.return_value.assert_has_calls(expected_calls)
@@ -516,16 +528,19 @@ class OutputToJson(unittest.TestCase):
                 "https://github.com/example/repo1",
                 31,
                 thirty_one_days_ago.date().isoformat(),
+                "private",
             ),
             (
                 "https://github.com/example/repo2",
                 30,
                 thirty_days_ago.date().isoformat(),
+                "private",
             ),
             (
                 "https://github.com/example/repo3",
                 29,
                 twenty_nine_days_ago.date().isoformat(),
+                "public",
             ),
         ]
 
@@ -536,16 +551,19 @@ class OutputToJson(unittest.TestCase):
                     "url": "https://github.com/example/repo1",
                     "daysInactive": 31,
                     "lastPushDate": thirty_one_days_ago.date().isoformat(),
+                    "visibility": "private",
                 },
                 {
                     "url": "https://github.com/example/repo2",
                     "daysInactive": 30,
                     "lastPushDate": thirty_days_ago.date().isoformat(),
+                    "visibility": "private",
                 },
                 {
                     "url": "https://github.com/example/repo3",
                     "daysInactive": 29,
                     "lastPushDate": twenty_nine_days_ago.date().isoformat(),
+                    "visibility": "public",
                 },
             ]
         )
@@ -567,16 +585,19 @@ class OutputToJson(unittest.TestCase):
                 "https://github.com/example/repo1",
                 31,
                 thirty_one_days_ago.date().isoformat(),
+                "private",
             ),
             (
                 "https://github.com/example/repo2",
                 30,
                 thirty_days_ago.date().isoformat(),
+                "private",
             ),
             (
                 "https://github.com/example/repo3",
                 29,
                 twenty_nine_days_ago.date().isoformat(),
+                "public",
             ),
         ]
 
@@ -587,16 +608,19 @@ class OutputToJson(unittest.TestCase):
                     "url": "https://github.com/example/repo1",
                     "daysInactive": 31,
                     "lastPushDate": thirty_one_days_ago.date().isoformat(),
+                    "visibility": "private",
                 },
                 {
                     "url": "https://github.com/example/repo2",
                     "daysInactive": 30,
                     "lastPushDate": thirty_days_ago.date().isoformat(),
+                    "visibility": "private",
                 },
                 {
                     "url": "https://github.com/example/repo3",
                     "daysInactive": 29,
                     "lastPushDate": twenty_nine_days_ago.date().isoformat(),
+                    "visibility": "public",
                 },
             ]
         )

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -487,7 +487,6 @@ class WriteToMarkdownTestCase(unittest.TestCase):
             call.write(
                 "The following repos have not had a push event for more than 365 days:\n\n"
             ),
-            call.write("| Repository URL | Days Inactive | Last Push Date | Visibility |\n"),
             call.write(
                 "| Repository URL | Days Inactive | Last Push Date | Visibility | "
             ),


### PR DESCRIPTION
# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Our priority was to archive public repositories that were not updated in a certain amount of inactive days.  This PR adds that information to the output.

- [x] update code/tests for new visibility column

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
