### PR TITLE
fix: permissions in Dockerfile when trying to output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,16 @@ LABEL com.github.actions.name="stale-repos" \
     org.opencontainers.image.vendor="GitHub" \
     org.opencontainers.image.description="Find stale repositories in a GitHub organization."
 
-
 WORKDIR /action/workspace
 COPY requirements.txt stale_repos.py /action/workspace/
 
-RUN python3 -m pip install --no-cache-dir -r requirements.txt \
+RUN useradd -m appuser \
+    && chown -R appuser:appuser /action/workspace \
+    && python3 -m pip install --no-cache-dir -r requirements.txt \
     && apt-get -y update \
     && apt-get -y install --no-install-recommends git-all=1:2.39.2-1.1 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m appuser
 USER appuser
 
 CMD ["/action/workspace/stale_repos.py"]


### PR DESCRIPTION
Fixes #98 

# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Needed to ensure the new appuser in the Dockerfile has permissions to write in the container.

If a bad actor tries to set `GITHUB_OUTPUT` to something like ../../output.json we will get an expected error

## Local Testing

<details>
<summary>Tested Dockerfile change locally by running:</summary>

```bash
> source .env
> docker build -t stalerepos .
> docker run -it --rm --name debug -e GH_APP_ID=${GH_APP_ID} \
  -e GH_APP_INSTALLATION_ID=${GH_APP_INSTALLATION_ID} \
  -e GH_APP_PRIVATE_KEY=${GH_APP_PRIVATE_KEY} \
  -e INACTIVE_DAYS=1 -e ORGANIZATION="[ORG]" \
  -v ${PWD}:/app stalerepos:latest
Starting stale repo search...
https://github.com/[ORG]/repo1: 2 days inactive
https://github.com/[ORG]/repo2: 2 days inactive
https://github.com/[ORG]/repo3: 2 days inactive
https://github.com/[ORG]/repo4: 52 days inactive
Found 4 stale repos in [ORG]
Wrote stale repos to stale_repos.json
Wrote stale repos to stale_repos.md
```

</details>

Tests: 22 passed in 0.16s

Black Linter: All done! ✨ 🍰 ✨. 2 files left unchanged.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
