### PR TITLE
chore: add black linter to `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,4 @@ lint:
 	flake8 . --count --select=E9,F63,F7,F82 --exclude .venv --show-source --statistics
 	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 	flake8 . --count --exclude .venv --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+	black .

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+black==24.2.0
 flake8==7.0.0
 pylint==3.1.0
 pytest==8.1.1


### PR DESCRIPTION
# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Since [super-linter isn't arm64 friendly yet](https://github.com/super-linter/super-linter/pull/5320) (what we use for linting in GitHub Actions on this repo), I'm a fan of adding black linter to `make lint`.

```bash
✗ make lint
pylint --rcfile=.pylintrc --fail-under=9.0 *.py

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

# stop the build if there are Python syntax errors or undefined names
flake8 . --count --select=E9,F63,F7,F82 --exclude .venv --show-source --statistics
0
# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
flake8 . --count --exclude .venv --exit-zero --max-complexity=10 --max-line-length=127 --statistics
0
black .
All done! ✨ 🍰 ✨
```

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
