### PR TITLE
fix: go back to root user in Dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 #checkov:skip=CKV_DOCKER_2
+#checkov:skip=CKV_DOCKER_3
 FROM python:3.12-slim
 LABEL com.github.actions.name="stale-repos" \
     com.github.actions.description="Find stale repositories in a GitHub organization." \
@@ -14,14 +15,10 @@ LABEL com.github.actions.name="stale-repos" \
 WORKDIR /action/workspace
 COPY requirements.txt stale_repos.py /action/workspace/
 
-RUN useradd -m appuser \
-    && chown -R appuser:appuser /action/workspace \
-    && python3 -m pip install --no-cache-dir -r requirements.txt \
+RUN python3 -m pip install --no-cache-dir -r requirements.txt \
     && apt-get -y update \
     && apt-get -y install --no-install-recommends git-all=1:2.39.2-1.1 \
     && rm -rf /var/lib/apt/lists/*
-
-USER appuser
 
 CMD ["/action/workspace/stale_repos.py"]
 ENTRYPOINT ["python3", "-u"]


### PR DESCRIPTION
Fixes: #101

# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Based on [GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#administrative-privileges:~:text=Note%3A%20GitHub%20Actions%20must%20be%20run%20by%20the%20default%20Docker%20user%20(root).%20Ensure%20your%20Dockerfile%20does%20not%20set%20the%20USER%20instruction%2C%20otherwise%20you%20will%20not%20be%20able%20to%20access%20GITHUB_WORKSPACE.) we will not be able to access the workspace of the GitHub Action without being the root user.  As a non-root user we won't be able to write to `$GITHUB_OUTPUT` which is an environment variable that is a path inside the workspace and GitHub Actions using to handle output from the GitHub Action.

Once that was realized, this seems to be the only possible path.

**fix:** ignore checkov linter requiring user in Dockerfile ([docs](https://www.checkov.io/2.Basics/Suppressing%20and%20Skipping%20Policies.html#dockerfile-example))

<details><summary>Running checkov locally</summary>
<p>

Note: CKV_DOCKER_3 is skipped

```
Check: CKV_DOCKER_3: "Ensure that a user for the container has been created"
	SKIPPED for resource: Dockerfile.
	Suppress comment: No comment provided
	File: Dockerfile:1-24
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/docker-policies/docker-policy-index/ensure-that-a-user-for-the-container-has-been-created
```

</p>
</details> 

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
