### PR TITLE
chore(deps): update dependabot config to include pr prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 ---
 version: 2
 updates:
@@ -9,11 +5,17 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ examples: "feat: add new logger" or "fix: remove unused imports"
 
 ### Reviewer
 
-- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
+- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
-black==24.4.0
+black==24.4.1
 flake8==7.0.0
-mypy==1.9.0
+mypy==1.10.0
 mypy-extensions==1.0.0
 pylint==3.1.0
 pytest==8.1.1


### PR DESCRIPTION
Closes #122
Closes #123

# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Add commit-message.prefix config option to dependabot so that dependabot pull request titles pass our new PR Title Linting workflow

- [x] include current dependency updates (black and mypy)
- [x] update pull_request_template.md with `maintenance` label option

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
