### PR TITLE
chore: add pull_request_target for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,94 +1,99 @@
 ---
-  name: Release
+name: Release
 
-  on:
-    workflow_dispatch:
-    pull_request:
-      types:
-        - closed
-      branches:
-        - main
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
 
-  permissions:
-    contents: read
+permissions:
+  contents: read
 
-  jobs:
-    create_release:
-      # release if
-      # manual deployment OR
-      # merged to main and labelled with release labels
-      if: |
-        (github.event_name == 'workflow_dispatch') ||
-        (github.event.pull_request.merged == true &&
-        (contains(github.event.pull_request.labels.*.name, 'breaking') ||
-        contains(github.event.pull_request.labels.*.name, 'enhancement') ||
-        contains(github.event.pull_request.labels.*.name, 'vuln') ||
-        contains(github.event.pull_request.labels.*.name, 'release')))
-      outputs:
-        full-tag: ${{ steps.release-drafter.outputs.tag_name }}
-        short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
-        body: ${{ steps.release-drafter.outputs.body }}
-      runs-on: ubuntu-latest
-      permissions:
-        contents: write
-        pull-requests: read
-      steps:
-        - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348
-          id: release-drafter
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            config-name: release-drafter.yml
-            publish: true
-        - name: Get the short tag
-          id: get_tag_name
-          run: |
-            short_tag=$(echo ${{ steps.release-drafter.outputs.tag_name }} | cut -d. -f1)
-            echo "SHORT_TAG=$short_tag" >> $GITHUB_OUTPUT
-    create_action_images:
-      needs: create_release
-      runs-on: ubuntu-latest
-      permissions:
-        packages: write
-      env:
-        REGISTRY: ghcr.io
-        IMAGE_NAME: github/stale_repos # different than repo name (underscore instead of dash)
-      steps:
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb
-        - name: Log in to the Container registry
-          uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
-          with:
-            registry: ${{ env.REGISTRY }}
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
-        - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - name: Push Docker Image
-          if: ${{ success() }}
-          uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
-          with:
-            context: .
-            file: ./Dockerfile
-            push: true
-            tags: |
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create_release.outputs.full-tag }}
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create_release.outputs.short-tag }}
-            platforms: linux/amd64
-            provenance: false
-            sbom: false
-    create_discussion:
-      needs: create_release
-      runs-on: ubuntu-latest
-      permissions:
-        discussions: write
-      steps:
-        - name: Create an announcement discussion for release
-          uses: abirismyname/create-discussion@6e6ef67e5eeb042343ef8b3d8d0f5d545cbdf024
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            title: ${{ needs.create_release.outputs.full-tag }}
-            body: ${{ needs.create_release.outputs.body }}
-            repository-id: ${{ secrets.RELEASE_DISCUSSION_REPOSITORY_ID }}
-            category-id: ${{ secrets.RELEASE_DISCUSSION_CATEGORY_ID }}
+jobs:
+  create_release:
+    # release if
+    # manual deployment OR
+    # merged to main and labelled with release labels
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'breaking') ||
+      contains(github.event.pull_request.labels.*.name, 'enhancement') ||
+      contains(github.event.pull_request.labels.*.name, 'vuln') ||
+      contains(github.event.pull_request.labels.*.name, 'release')))
+    outputs:
+      full-tag: ${{ steps.release-drafter.outputs.tag_name }}
+      short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
+      body: ${{ steps.release-drafter.outputs.body }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348
+        id: release-drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: release-drafter.yml
+          publish: true
+      - name: Get the short tag
+        id: get_tag_name
+        run: |
+          short_tag=$(echo ${{ steps.release-drafter.outputs.tag_name }} | cut -d. -f1)
+          echo "SHORT_TAG=$short_tag" >> $GITHUB_OUTPUT
+  create_action_images:
+    needs: create_release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: github/stale_repos # different than repo name (underscore instead of dash)
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb
+      - name: Log in to the Container registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Push Docker Image
+        if: ${{ success() }}
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create_release.outputs.full-tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create_release.outputs.short-tag }}
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+  create_discussion:
+    needs: create_release
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+    steps:
+      - name: Create an announcement discussion for release
+        uses: abirismyname/create-discussion@6e6ef67e5eeb042343ef8b3d8d0f5d545cbdf024
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: ${{ needs.create_release.outputs.full-tag }}
+          body: ${{ needs.create_release.outputs.body }}
+          repository-id: ${{ secrets.RELEASE_DISCUSSION_REPOSITORY_ID }}
+          category-id: ${{ secrets.RELEASE_DISCUSSION_CATEGORY_ID }}

--- a/.github/workflows/use-action.yml
+++ b/.github/workflows/use-action.yml
@@ -1,6 +1,5 @@
 ---
 name: stale repo identifier
-
 on:
   workflow_dispatch:
   push:
@@ -9,10 +8,8 @@ on:
   pull_request:
   schedule:
     - cron: '3 2 1 * *'
-
 permissions:
   contents: read
-
 jobs:
   build:
     name: stale repo identifier


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] add pull_request_target to release GitHub Action so we have access to fork PR labels

I am not worried about the security implications with us checking out the forked pull requests code. This action only fires after a merge to main so this means the pull request code has been reviewed by a maintainer. We are post-CI/code run.


## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
