### PR TITLE
chore: standardize github action types

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,24 +1,24 @@
 ---
-  name: Auto Labeler
+name: Auto Labeler
 
-  on:
-    # pull_request_target event is required for autolabeler to support all PRs including forks
-    pull_request_target:
-      types: [opened, reopened, synchronize]
+on:
+  # pull_request_target event is required for autolabeler to support all PRs including forks
+  pull_request_target:
+    types: [ opened, reopened, edited, synchronize ]
 
-  permissions:
-    contents: read
+permissions:
+  contents: read
 
-  jobs:
-    main:
-      permissions:
-        contents: write
-        pull-requests: write
-      name: Auto label pull requests
-      runs-on: ubuntu-latest
-      steps:
-        - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            config-name: release-drafter.yml
+jobs:
+  main:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Auto label pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: release-drafter.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,9 +3,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -3,7 +3,7 @@ name: Lint Code Base
 
 on:
   pull_request:
-    branches: main
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -3,7 +3,7 @@ name: Major Version Updater
 # Whenever a new release is made, push a major version tag
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,10 +4,7 @@ name: "Lint PR Title"
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+    types: [ opened, reopened, edited, synchronize ]
 
 permissions:
   contents: read

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,8 @@ name: Release
 on:
   workflow_dispatch:
   pull_request_target:
-    types:
-      - closed
-    branches:
-      - main
+    types: [ closed ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     - cron: '29 11 * * 6'
   push:
-    branches: ["main"]
+    branches: [ main ]
 
 permissions: read-all
 

--- a/.github/workflows/use-action.yml
+++ b/.github/workflows/use-action.yml
@@ -3,8 +3,7 @@ name: stale repo identifier
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
   schedule:
     - cron: '3 2 1 * *'


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] use one line lists for types and branches
- [x] fix formatting (random 2 space column on some of the workflows)
- [x] add `edited` and `reopened` to some of the workflows

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
