### PR TITLE
ci: hard coded dates to declarative

### DIFF
--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -317,7 +317,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
             {
                 "url": "https://github.com/example/repo2",
                 "days_inactive": 40,
-                "last_push_date": "2024-04-29",
+                "last_push_date": forty_days_ago.date().isoformat(),
                 "visibility": "private",
                 "days_since_last_release": None,
                 "days_since_last_pr": None,
@@ -468,7 +468,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
             {
                 "url": "https://github.com/example/repo2",
                 "days_inactive": 40,
-                "last_push_date": "2024-04-29",
+                "last_push_date": forty_days_ago.date().isoformat(),
                 "visibility": "private",
                 "days_since_last_release": None,
                 "days_since_last_pr": None,
@@ -544,7 +544,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
             {
                 "url": "https://github.com/example/repo2",
                 "days_inactive": 40,
-                "last_push_date": "2024-04-29",
+                "last_push_date": forty_days_ago.date().isoformat(),
                 "visibility": "private",
                 "days_since_last_release": None,
                 "days_since_last_pr": None,


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
This pull request makes changes to the test functions `test_get_inactive_repos_with_inactive_repos`, `test_get_inactive_repos_with_no_organization_set`, and `test_get_inactive_repos_with_default_branch_updated`. The changes consist of replacing a hard-coded date string with a dynamic date value, `forty_days_ago.date().isoformat()`, for the `last_push_date` key in the test data. This makes the tests more robust and not reliant on a fixed date.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
