### PR TITLE
feat: make skipping empty report creation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This action can be configured to authenticate with GitHub App Installation or Pe
 | `EXEMPT_TOPICS`      | false    |            | Comma separated list of topics to exempt from being flagged as stale                                                                                                                                                                                                    |
 | `ORGANIZATION`       | false    |            | The organization to scan for stale repositories. If no organization is provided, this tool will search through repositories owned by the GH_TOKEN owner                                                                                                                 |
 | `ADDITIONAL_METRICS` | false    |            | Configure additional metrics like days since last release or days since last pull request. This allows for more detailed reporting on repository activity. To include both metrics, set `ADDITIONAL_METRICS: "release,pr"`                                              |
+| `SKIP_EMPTY_REPORTS` | false    | `true`     | Skips report creation when no stale repositories are identified. Setting this input to `false` means reports are always created, even when they contain no results.                                                                                                     |
 
 ### Example workflow
 

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -41,6 +41,9 @@ def main():  # pragma: no cover
     gh_app_private_key = os.getenv("GH_APP_PRIVATE_KEY").encode("utf8")
     ghe = os.getenv("GH_ENTERPRISE_URL")
     gh_app_enterprise_only = os.getenv("GITHUB_APP_ENTERPRISE_ONLY")
+    skip_empty_reports = (
+        False if os.getenv("SKIP_EMPTY_REPORTS").lower() == "false" else True
+    )
 
     # Auth to GitHub.com or GHE
     github_connection = auth.auth_to_github(
@@ -73,11 +76,11 @@ def main():  # pragma: no cover
         github_connection, inactive_days_threshold, organization, additional_metrics
     )
 
-    if inactive_repos:
+    if inactive_repos or not skip_empty_reports:
         output_to_json(inactive_repos)
         write_to_markdown(inactive_repos, inactive_days_threshold, additional_metrics)
     else:
-        print("No stale repos found")
+        print("Reporting skipped; no stale repos found.")
 
 
 def is_repo_exempt(repo, exempt_repos, exempt_topics):


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Add SKIP_EMPTY_REPORTS as an option which defaults to the existing behavior, but allows creation of empty reports when needed. This can be especially useful for workflows that update existing issues.

This was initially discussed in and potentially closes #290

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
   -  `make test` runs successfully, but no tests were added as the changes only configure whether or not to call output functions
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
