### PR TITLE
chore: add major version updater workflow back

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,0 +1,5 @@
+quiet: true
+skip-check:
+  - CKV_GHA_7
+  - CKV_DOCKER_2
+  - CKV_DOCKER_3

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -1,3 +1,4 @@
+#checkov:skip=CKV_GHA_7
 name: Update major tag for release
 on:
   release:

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -1,4 +1,3 @@
-#checkov:skip=CKV_GHA_7
 name: Update major tag for release
 on:
   release:

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -1,0 +1,24 @@
+name: Update major tag for release
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: "Tag name that the major tag will point to (e.g. v1.2.3)"
+        required: true
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: read
+jobs:
+  update_tag:
+    permissions:
+      contents: write
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update the ${{ env.TAG_NAME }} tag
+        uses: actions/publish-action@8a4b4f687b72f481b8a241ef71f38857239698fc
+        with:
+          source-tag: ${{ env.TAG_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-#checkov:skip=CKV_DOCKER_2
-#checkov:skip=CKV_DOCKER_3
 FROM python:3.13-slim@sha256:8f3aba466a471c0ab903dbd7cb979abd4bda370b04789d25440cc90372b50e04
 LABEL com.github.actions.name="stale-repos" \
     com.github.actions.description="Find stale repositories in a GitHub organization." \


### PR DESCRIPTION
Related to https://github.com/github/stale-repos/discussions/272

Accidentally removed during previous cleanup

We're going to use actions/release-action since it simplifies some things and already have example from actions/stale usage

- [x] Centralize checkov checks to skip in `linters/.checkov.yml`
  - CKV_GHA_7 was failing for this new action, it is invalid
  - CKV_DOCKER_2, CKV_DOCKER_3 were on the Dockerfil previously

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `make lint` and fix any issues that you have introduced
- [ ] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
