### PR TITLE
fix: brought back the original script

### DIFF
--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -1,14 +1,14 @@
 name: Update major tag for release
 on:
   release:
-    types: [released]
+    types: [published]
   workflow_dispatch:
     inputs:
       TAG_NAME:
         description: "Tag name that the major tag will point to (e.g. v1.2.3)"
         required: true
 env:
-  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.ref}}
 permissions:
   contents: write
 jobs:
@@ -16,8 +16,16 @@ jobs:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
     runs-on: ubuntu-latest
     steps:
-      - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@8a4b4f687b72f481b8a241ef71f38857239698fc
-        with:
-          source-tag: ${{ env.TAG_NAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout Repo
+        uses: actions/checkout@v4.2.2
+      - name: version
+        id: version
+        run: |
+          tag=${TAG_NAME/refs\/tags\//}
+          version=${tag#v}
+          major=${version%%.*}
+          { echo "tag=${tag}"; echo "version=${version}"; echo "major=${major}"; } >> "$GITHUB_OUTPUT"
+      - name: force update major tag
+        run: |
+          git tag v${{ steps.version.outputs.major }}
+          git push origin refs/tags/v${{ steps.version.outputs.major }} -f


### PR DESCRIPTION
- [x] extended to allow manual run

Found https://github.com/orgs/community/discussions/116660 which showed the _exact_ error I was getting with actions/publish-action.

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `make lint` and fix any issues that you have introduced
- [ ] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
