### PR TITLE
fix: output of printed repo url does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
         uses: peter-evans/create-issue-from-file@v5
         with:
           issue-number: ${{ env.issue_number }}
-          title: Stale repository report
+          title: Stale-repository-report
           content-filepath: ./stale_repos.md
           assignees: <YOUR_GITHUB_HANDLE_HERE>
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run stale_repos tool
-        uses: github/stale-repos@v1
+        uses: github/stale-repos@v2
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ secrets.ORGANIZATION }}
@@ -109,7 +109,7 @@ jobs:
       # This next step updates an existing issue. If you want a new issue every time, remove this step and remove the `issue-number: ${{ env.issue_number }}` line below.
       - name: Check for the stale report issue
         run: |
-          ISSUE_NUMBER=$(gh search issues "Stale repository report" --match title --json number --jq ".[0].number")
+          ISSUE_NUMBER=$(gh search issues "Stale-repository-report" --match title --json number --jq ".[0].number")
           echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
     steps:
       - name: Run stale_repos tool
         id: stale-repos
-        uses: github/stale-repos@v1
+        uses: github/stale-repos@v2
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ secrets.ORGANIZATION }}
@@ -210,7 +210,7 @@ jobs:
         org: [org1, org2]
     steps:
       - name: "run stale-repos"
-        uses: github/stale-repos@v1
+        uses: github/stale-repos@v2
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ matrix.org }}
@@ -237,10 +237,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run stale_repos tool
-        uses: github/stale-repos@v1
+        uses: github/stale-repos@v2
         env:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -386,7 +386,7 @@ def set_repo_data(
  Potentially caused by ghost user."
                 )
 
-    print(f"{repo.html_url}: {days_inactive} days inactive")  # type: ignore
+    print(f"{repo.html_url} {days_inactive} days inactive")  # type: ignore
     return repo_data
 
 

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -209,7 +209,7 @@ class GetInactiveReposTestCase(unittest.TestCase):
         expected_output = (
             f"Exempt topics: ['topic1', 'topic2']\n"
             f"https://github.com/example/repo is exempt from stale repo check\n"
-            f"https://github.com/example/repo2: 30 days inactive\n"
+            f"https://github.com/example/repo2 30 days inactive\n"
             f"Found 1 stale repos in {organization}\n"
         )
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
## Proposed Changes

- Updated README: Updated references in the README file to reflect the latest version numbers.
- Renamed default issue title: Changed the default issue name from "Stale repository report" to "Stale-repository-report". This reduces false positives when searching with the GitHub CLI, as the original name could match any of the individual words.
- Fixed broken URL in action message: Removed an unintended colon at the end of a printed URL, which was preventing the link from working correctly.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
