### PR TITLE
fix: catch error that occurs when ghost user made a release.

### DIFF
--- a/stale_repos.py
+++ b/stale_repos.py
@@ -187,10 +187,10 @@ def get_days_since_last_release(repo):
     try:
         last_release = next(repo.releases())
         return (datetime.now(timezone.utc) - last_release.created_at).days
-    except TypeError as e:
+    except TypeError:
         print(
-            f"{repo.html_url} had an exception trying to get the activity date.\
-        Potentially caused by ghost user."
+            f"{repo.html_url} had an exception trying to get the last release.\
+            Potentially caused by ghost user."
         )
         return None
     except StopIteration:

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -187,6 +187,12 @@ def get_days_since_last_release(repo):
     try:
         last_release = next(repo.releases())
         return (datetime.now(timezone.utc) - last_release.created_at).days
+    except TypeError as e:
+        print(
+            f"{repo.html_url} had an exception trying to get the activity date.\
+        Potentially caused by ghost user."
+        )
+        return None
     except StopIteration:
         return None
 


### PR DESCRIPTION

> [!TIP]
> Basically, a port of https://github.com/github/issue-metrics/pull/325 with almost exactly the same explanation in this PR

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

This pull request changes the `get_days_since_last_release` function in the `stale_repos.py` file. The change introduces error handling to deal with potential `TypeError` exceptions that might occur when processing a release. If such an error occurs, a message is printed to inform the user that the release might contain a ghost user, and `None` is returned.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
