### PR TITLE
chore: bump action versions in README examples and docker image to v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run stale_repos tool
-        uses: github-community-projects/stale-repos@v7
+        uses: github-community-projects/stale-repos@v9
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ secrets.ORGANIZATION }}
@@ -126,7 +128,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create issue
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           issue-number: ${{ env.issue_number }}
           title: Stale-repository-report
@@ -157,7 +159,7 @@ jobs:
 
     steps:
       - name: Run stale_repos tool
-        uses: github-community-projects/stale-repos@v7
+        uses: github-community-projects/stale-repos@v9
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ secrets.ORGANIZATION }}
@@ -206,7 +208,7 @@ jobs:
     steps:
       - name: Run stale_repos tool
         id: stale-repos
-        uses: github-community-projects/stale-repos@v7
+        uses: github-community-projects/stale-repos@v9
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ secrets.ORGANIZATION }}
@@ -216,7 +218,7 @@ jobs:
 
       - name: Print output of stale_repos tool
         run: echo "${{ steps.stale-repos.outputs.inactiveRepos }}"
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             const repos = ${{ steps.stale-repos.outputs.inactiveRepos }}
@@ -255,7 +257,7 @@ jobs:
         org: [org1, org2]
     steps:
       - name: "run stale-repos"
-        uses: github-community-projects/stale-repos@v7
+        uses: github-community-projects/stale-repos@v9
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: ${{ matrix.org }}
@@ -282,10 +284,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run stale_repos tool
-        uses: github-community-projects/stale-repos@v7
+        uses: github-community-projects/stale-repos@v9
         env:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ outputs:
     description: "Inactive Repos in the organization"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/github-community-projects/stale_repos:v7"
+  image: "docker://ghcr.io/github-community-projects/stale_repos:v9"
 branding:
   icon: "check-square"
   color: "white"


### PR DESCRIPTION
## What

Our latest release is v9, we need the references of stale-repos to be v9, especially the action.yml

Updated all GitHub Action version references in README.md examples and the Docker image tag in action.yml to their latest major versions.

## Why

The documented examples and action definition referenced outdated action versions. Bumping to current versions ensures users get security fixes, performance improvements, and new features from upstream dependencies.

## Notes

- `actions/checkout` bumped from v4 to v6 with `persist-credentials: false` added for security hardening
- `peter-evans/create-issue-from-file` bumped from v5 to v6
- `actions/github-script` bumped from v6 to v8
- The `action.yml` Docker image tag change from v7 to v9 means this is a breaking release boundary — consumers pinned to v7 will not pick up this change until they update their workflow references

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
